### PR TITLE
#36 Security fix

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -104,11 +104,11 @@ module.exports = function (opts) {
 function getBrowser (target, dataDir) {
     dataDir = dataDir || 'temp_chrome_user_data_dir_for_cordova';
 
-    const chromeArgs = ` --user-data-dir=/tmp/${dataDir}`;
+    const chromeArgs = ` --user-data-dir="/tmp/${dataDir}"`;
     const browsers = {
         win32: {
             ie: 'iexplore',
-            chrome: `chrome --user-data-dir=%TEMP%\\${dataDir}`,
+            chrome: `chrome --user-data-dir="%TEMP%\\${dataDir}"`,
             safari: 'safari',
             opera: 'opera',
             firefox: 'firefox',


### PR DESCRIPTION
### Platforms affected

All

### Motivation and Context

Fix for #36

### Description

I added quotes in the getBrowser method to escape potentially malicious user input for dataDir on my Windows machine and in a Unix docker image.

### Testing

Tested various commands on windows shell to check that the quotes would escape potentially malicious content. No automated test added for the change.

### Checklist

- [ X] I've run the tests to see all new and existing tests pass
- [ X] I added automated test coverage as appropriate for this change
- [ X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ X] I've updated the documentation if necessary
