### PR TITLE
Fix Remote Code Execution

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -24,6 +24,7 @@ const fs = require('fs');
 const open = require('open');
 const which = require('which');
 const exec = require('./exec');
+const path = require('path');
 
 const NOT_INSTALLED = 'The browser target is not installed: %target%';
 const NOT_SUPPORTED = 'The browser target is not supported: %target%';
@@ -40,7 +41,7 @@ const NOT_SUPPORTED = 'The browser target is not supported: %target%';
 module.exports = function (opts) {
     opts = opts || {};
     let target = opts.target || 'default';
-    const url = opts.url || '';
+    const url = encodeURI(opts.url) || '';
 
     target = target.toLowerCase();
     if (target === 'default') {
@@ -103,6 +104,12 @@ module.exports = function (opts) {
 
 function getBrowser (target, dataDir) {
     dataDir = dataDir || 'temp_chrome_user_data_dir_for_cordova';
+    if (dataDir !== "") {
+        var validateDir = /^[0-9a-zA-Z._\s-%$]+$/i.test(dataDir);
+        if (validateDir === false){
+            throw new Error('Invalid directory name');
+        }
+    }
 
     const chromeArgs = ` --user-data-dir=/tmp/${dataDir}`;
     const browsers = {


### PR DESCRIPTION
### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL: https://www.huntr.dev/app/bounties/open/1-npm-cordova-serve

### ⚙️ Description *

The cordova-serve module suffers from remote code execution caused by the lack of validating dataDir & URL input arguments before executing the command in [#L89](https://github.com/apache/cordova-serve/blob/bbe740cd70dc31f91537864b39a8569d394205f0/src/browser.js#L89). The proposed fix will add a check for both inputs.

### 💻 Technical Description *

According to cordova-serve documentation `dataDir` & `URL` are described as:

_dataDir - a data dir to provide to Chrome (can be used to force it to open in a new window)_
_url - the url to open in the browser_

Types of the parameters
```javascript
@param url: string, dataDir: string
``` 

For the `dataDir` input I added a regex check which will make sure that the input doesn't contain any illegal character (which can result in RCE). If the validation fails it will print an error message


For the `URL` input I simply used `encodeURI` function which will encode the input as URL and give it to the chrome. If any extra command were added it will still be considered as a part of URL

### 🐛 Proof of Concept (PoC) *
```shell
node poc.js
```

```node
// poc.js
const cordovaServe = require('./src/main.js');

var server = cordovaServe();

cordovaServe.launchBrowser({target: "chrome", url: "http://localhost", dataDir: "; touch hbkhan"}).then(
  stdout => {
    console.log(`Browser was launched successfully: ${stdout}`);
  },
  error => {
    console.log(`An error occurred: ${error}`);
  }
);
```
![poc1](https://user-images.githubusercontent.com/17072444/85353051-fd0c6f00-b4cc-11ea-9973-d1899c3c3ce2.PNG)



```shell
node poc2.js
```

```node
// poc2.js
const cordovaServe = require('./src/main.js');
var server = cordovaServe();
cordovaServe.launchBrowser({target: "chrome", url: "http://localhost; touch hbkhan", dataDir: ""}).then(
  stdout => {
    console.log(`Browser was launched successfully: ${stdout}`);
  },
  error => {
    console.log(`An error occurred: ${error}`);
  }
);
```

![poc2](https://user-images.githubusercontent.com/17072444/85353150-33e28500-b4cd-11ea-808c-e2e7fd0ea852.PNG)



### 🔥 Proof of Fix (PoF) *

```shell
node poc.js
```

```node
// poc.js
const cordovaServe = require('./src/main.js');

var server = cordovaServe();

cordovaServe.launchBrowser({target: "chrome", url: "http://localhost", dataDir: "; touch hbkhan"}).then(
  stdout => {
    console.log(`Browser was launched successfully: ${stdout}`);
  },
  error => {
    console.log(`An error occurred: ${error}`);
  }
);
```

![fix_poc1](https://user-images.githubusercontent.com/17072444/85353137-2f1dd100-b4cd-11ea-9b68-e9d580d2cffd.PNG)


```node
// poc2.js
const cordovaServe = require('./src/main.js');
var server = cordovaServe();
cordovaServe.launchBrowser({target: "chrome", url: "http://localhost; touch hbkhan", dataDir: ""}).then(
  stdout => {
    console.log(`Browser was launched successfully: ${stdout}`);
  },
  error => {
    console.log(`An error occurred: ${error}`);
  }
);
```
![fix_poc2](https://user-images.githubusercontent.com/17072444/85353170-3d6bed00-b4cd-11ea-9034-60d06063c052.PNG)




### 👍 User Acceptance Testing (UAT)

```code
w'h'o'am'i
w\ho\am\i
echo test >> test
whoami
```
